### PR TITLE
Problem: cannot verify contract on sepolia

### DIFF
--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
-    "@nomiclabs/hardhat-etherscan": "^2.1.0",
+    "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@nomiclabs/hardhat-solpp": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@openzeppelin/contracts": "4.8.0",

--- a/ethereum/scripts/deploy.ts
+++ b/ethereum/scripts/deploy.ts
@@ -49,7 +49,7 @@ async function main() {
             });
 
             // Create2 factory already deployed on the public networks, only deploy it on local node
-            if (process.env.CHAIN_ETH_NETWORK === 'localhost') {
+            if (process.env.CHAIN_ETH_NETWORK === 'localhost' || process.env.CHAIN_ETH_NETWORK === 'sepolia') {
                 await deployer.deployCreate2Factory({ gasPrice, nonce });
                 nonce++;
             }


### PR DESCRIPTION
Upgrade hardhat etherscan to be able to verify contract on sepolia

(Sepolia network is not supported before version 3)